### PR TITLE
Upgrade to the recent version of @adonisjs/core

### DIFF
--- a/instructions.ts
+++ b/instructions.ts
@@ -153,21 +153,21 @@ export default async function instructions (
     react: frontendFramework === 'react',
     vue: frontendFramework === 'vue',
   }).commit()
-  sink.logger.create(configPath)
+  sink.logger.action('create').succeeded(configPath)
 
   const cssFilePath = app.resourcesPath(`${cssLang}/app.${cssLang}`)
   const cssFile = new sink.files.MustacheFile(projectRoot, cssFilePath, getStub('app.txt'))
   cssFile.apply({
     lang: cssLang,
   }).commit()
-  sink.logger.create(cssFilePath)
+  sink.logger.action('create').succeeded(cssFilePath)
 
   const jsFilePath = app.resourcesPath(`${typescript ? 'ts' : 'js'}/app.${typescript ? 'ts' : 'js'}`)
   const jsFile = new sink.files.MustacheFile(projectRoot, jsFilePath, getStub('app.txt'))
   jsFile.apply({
     lang: typescript ? 'TypeScript' : 'JavaScript',
   }).commit()
-  sink.logger.create(jsFilePath)
+  sink.logger.action('create').succeeded(jsFilePath)
 
   pkg.install('@symfony/webpack-encore', undefined, true)
   pkg.install('webpack-notifier', undefined, true)
@@ -175,16 +175,20 @@ export default async function instructions (
   /**
    * Install required dependencies
    */
-  sink.logger.info(`Installing packages: ${pkg.getInstalls().list.join(', ')}...`)
-
+  const spinner = sink.logger.await(`Installing packages: ${pkg.getInstalls().list.join(', ')}...`)
   await pkg.commitAsync()
+  spinner.stop()
 
   sink.logger.success('Packages installed!')
+  console.log(' ')
 
   /**
    * Usage instructions
    */
-  console.log(' ')
-  console.log(`   ${sink.colors.gray('$')} Run ${sink.colors.cyan('npm run build:front')} to start the build`)
-  console.log(`   ${sink.colors.gray('$')} Run ${sink.colors.cyan('npm run build:front:prod')} to build for production`)
+  sink
+    .instructions()
+    .heading('Run following commands to get started')
+    .add(`${sink.logger.colors.cyan('npm run build:front')} to start the build`)
+    .add(`${sink.logger.colors.cyan('npm run build:front:prod')} to build for production`)
+    .render()
 }

--- a/package.json
+++ b/package.json
@@ -40,11 +40,10 @@
     "url": "https://github.com/Slynova-Org/symfony-encore/issues"
   },
   "devDependencies": {
-    "@adonisjs/application": "^1.3.16",
-    "@adonisjs/core": "^5.0.0-preview-rc-1.9",
-    "@adonisjs/fold": "^6.3.5",
+    "@adonisjs/core": "^5.0.2-beta-rc-6",
     "@adonisjs/mrm-preset": "^2.3.7",
-    "@adonisjs/sink": "^3.0.2",
+    "@adonisjs/require-ts": "^1.0.4",
+    "@adonisjs/sink": "^4.1.3",
     "commitizen": "^4.1.2",
     "copyfiles": "^2.3.0",
     "cz-conventional-changelog": "^3.2.0",
@@ -52,8 +51,7 @@
     "eslint": "^7.4.0",
     "eslint-plugin-adonis": "^1.0.14",
     "np": "^6.3.2",
-    "ts-node": "^8.10.2",
-    "typescript": "^3.9.6"
+    "typescript": "^4.0.3"
   },
   "config": {
     "commitizen": {

--- a/providers/EncoreProvider.ts
+++ b/providers/EncoreProvider.ts
@@ -1,19 +1,19 @@
 import { readFile } from 'fs/promises'
-import { IocContract } from '@adonisjs/fold'
 import { ApplicationContract } from '@ioc:Adonis/Core/Application'
 
 export default class EncoreProvider {
-  constructor (protected $container: IocContract) {}
+  constructor (protected application: ApplicationContract) {}
+  public static needsApplication = true
 
   public async boot () {
-    if (!this.$container.hasBinding('Adonis/Core/View')) {
-      throw new Error('You need to install the @adonisjs/view package to use this package.')
+    if (!this.application.container.hasBinding('Adonis/Core/View')) {
+      throw new Error('You need to install the @adonisjs/view package to use this package')
     }
 
-    this.$container.with(['Adonis/Core/Application', 'Adonis/Core/View'],
-      async (Application: ApplicationContract, View) => {
+    this.application.container.with(['Adonis/Core/View'],
+      async (View) => {
         try {
-          const entrypointsFilePath = Application.publicPath('/build/entrypoints.json')
+          const entrypointsFilePath = this.application.publicPath('/build/entrypoints.json')
           const entrypointsFile = await readFile(entrypointsFilePath)
           const { entrypoints, integrity } = JSON.parse(entrypointsFile.toString())
 


### PR DESCRIPTION
This includes breaking changes since the provider now accepts an instance of the application.

## Changes includes

- Use latest version of sink
- Accept application instance inside providers
- Remove all other AdonisJS specific dev dependencies accept `@adonisjs/sink` and `@adonisjs/core`